### PR TITLE
Remove unnecessary publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
       - *attach_workspace
       - build-helpers/authenticate_npm
       - run: npm publish
-      - build-helpers/push_package_to_npm
       - *persist_to_workspace
   github_release:
     executor: hedwig


### PR DESCRIPTION
Build will pass with this - `npm publish` is good enough.