### PR TITLE
fix: Add eslintrc info and 'use strict' to template

### DIFF
--- a/generators/node/index.js
+++ b/generators/node/index.js
@@ -162,7 +162,7 @@ module.exports = class extends Generator {
 					type: 'checkbox',
 					name: 'smartAppPermissions',
 					pageSize: 5,
-					message: chalk.hex('#15bfff').bold.underline('What permission scopes does your SmartApp need? ') + chalk.gray('The fewer, the better!'),
+					message: chalk.hex('#15bfff').bold.underline('What permission scopes does your SmartApp need? ') + chalk.dim('The fewer, the better!'),
 					choices: [
 						{name: 'Read devices ' + chalk.dim.italic('Read details about a device'), value: 'r:devices:*', checked: true},
 						{name: 'Execute devices ' + chalk.dim.italic('Execute commands on a device'), value: 'x:devices:*'},
@@ -413,8 +413,8 @@ module.exports = class extends Generator {
 					suffix: ' Must be installed globally',
 					default: 'npm',
 					choices: [
-						{name: chalk.redBright.italic('npm'), value: 'npm'},
-						{name: chalk.blueBright.italic('yarn'), value: 'yarn'}
+						{name: chalk.redBright('npm'), value: 'npm'},
+						{name: chalk.blueBright('yarn'), value: 'yarn'}
 					]
 				}).then(pkgManagerAnswer => {
 					generator.appConfig.pkgManager = pkgManagerAnswer.pkgManager
@@ -607,8 +607,9 @@ module.exports = class extends Generator {
 			case 'eslint':
 				extensionsJson.recommendations.push('dbaeumer.vscode-eslint')
 				pkgJson.devDependencies.eslint = '^5.16.0'
-				pkgJson.scripts.lint = 'eslint'
-				pkgJson.scripts['lint:fix'] = 'eslint --fix'
+				pkgJson.devDependencies['eslint-config-strongloop'] = '^2.1.0'
+				pkgJson.scripts.lint = 'eslint --ignore-path .gitignore .'
+				pkgJson.scripts['lint:fix'] = 'eslint --fix --ignore-path .gitignore .'
 				this.fs.copyTpl(this.sourceRoot() + '/.eslintrc.json', context.name + '/.eslintrc.json', context)
 				break
 			default: break

--- a/generators/node/templates/app-smartapp/.eslintrc.json
+++ b/generators/node/templates/app-smartapp/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": "strongloop",
+  "parserOptions": {
+      "ecmaVersion": 2017
+  },
+  "env": {
+      "es6": true
+  },
+  "rules": {
+      "max-len": "off"
+  }
+}

--- a/generators/node/templates/app-smartapp/app.js
+++ b/generators/node/templates/app-smartapp/app.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env nodejs
+'use strict'
+
 const SmartApp = require('@smartthings/smartapp')
 <% if (contextStoreProvider === 'dynamodb') { _%>
 const DynamoDBContextStore = require('@smartthings/dynamodb-context-store')


### PR DESCRIPTION
This makes the end-result of the eslint path a little cleaner by adding a complete eslintrc (strongloop) with some adjustments, and then runs the full eslint --fix after installing. 

Honorable mentions: text style tweaks to make it more readable. `chalk.dim()` seems to be really well supported across different colored terminals.