### PR TITLE
fix: use composeWith() instead of run()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 If you have NPM install (`5.2.0`+), just run the following command from a root repository directory:
 
 ```bash
+npx yo smartthings
+```
+
+or,
+
+```bash
 npm init yo smartthings
 ```
 
@@ -36,12 +42,34 @@ Then generate your new project:
 yo smartthings
 ```
 
+## Developing
+
+### Debugging guide
+
+* From the source directory:
+
+```bash
+npm link
+```
+
+* From anywhere:
+
+```bash
+node --inspect `which yo` smartthings
+```
+
+* For additional debug logging from Yeoman itself:
+
+```bash
+DEBUG=yeoman:generator node --inspect `which yo` smartthings
+```
+
 ## Getting To Know Yeoman
 
-- Yeoman has a heart of gold.
-- Yeoman is a person with feelings and opinions, but is very easy to work with.
-- Yeoman can be too opinionated at times but is easily convinced not to be.
-- Feel free to [learn more about Yeoman](http://yeoman.io/).
+* Yeoman has a heart of gold.
+* Yeoman is a person with feelings and opinions, but is very easy to work with.
+* Yeoman can be too opinionated at times but is easily convinced not to be.
+* Feel free to [learn more about Yeoman](http://yeoman.io/).
 
 ## More about SmartThings
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -25,7 +25,7 @@ module.exports = class extends Generator {
 	}
 
 	async end() {
-		this.env.run(`smartthings:${this.answers.language}`, {
+		this.composeWith(require.resolve(`../${this.answers.language}`), {
 			skipWelcome: true
 		})
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-smartthings",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This may fix resolving sub-generators. It solved it locally but `npm init yo` seems to behave differently which cannot be tested effectively locally.
